### PR TITLE
Add hardware signing and key exporting

### DIFF
--- a/atecc608a_se.c
+++ b/atecc608a_se.c
@@ -20,10 +20,6 @@
  *  limitations under the License.
  */
 #include "atecc608a_se.h"
-
-#include "psa/crypto.h"
-
-#include "atca_basic.h"
 #include "atca_helpers.h"
 
 #ifdef DEBUG_PRINT
@@ -35,26 +31,6 @@
 
 /* Uncomment to print results on success */
 //#define DEBUG_PRINT
-
-#define ATCAB_INIT()                                        \
-    do                                                      \
-    {                                                       \
-        if (atcab_init(&atca_iface_config) != ATCA_SUCCESS) \
-        {                                                   \
-            status = PSA_ERROR_HARDWARE_FAILURE;            \
-            goto exit;                                      \
-        }                                                   \
-    } while(0)
-
-/** `atcab_release()` might return `ATCA_BAD_PARAM` if there is no global device
- *  initialized via `atcab_init()`. HAL might return an error if an i2c device
- *  cannot be released, but in current implementations it always returns
- *  `ATCA_SUCCESS` - therefore we are ignoring the return code. */
-#define ATCAB_DEINIT()    \
-    do                    \
-    {                     \
-        atcab_release();  \
-    } while(0)
 
 /** This macro checks if the result of an `expression` is equal to an
  *  `expected` value and sets a `status` variable of type `psa_status_t` to
@@ -77,7 +53,7 @@
 #define ASSERT_SUCCESS(expression) ASSERT_STATUS(expression, ATCA_SUCCESS, \
                                       atecc608a_to_psa_error(ASSERT_result))
 
-static ATCAIfaceCfg atca_iface_config = {
+ATCAIfaceCfg atca_iface_config = {
     .iface_type = ATCA_I2C_IFACE,
     .devtype = ATECC608A,
     .atcai2c.slave_address = 0xC0,
@@ -87,7 +63,7 @@ static ATCAIfaceCfg atca_iface_config = {
     .rx_retries = 20,
 };
 
-static psa_status_t atecc608a_to_psa_error(ATCA_STATUS ret)
+psa_status_t atecc608a_to_psa_error(ATCA_STATUS ret)
 {
     switch (ret)
     {

--- a/atecc608a_se.c
+++ b/atecc608a_se.c
@@ -66,11 +66,11 @@ static psa_status_t atecc608a_to_psa_error(ATCA_STATUS ret)
         return PSA_SUCCESS;
     case ATCA_BAD_PARAM:
     case ATCA_INVALID_ID:
-    case ATCA_INVALID_SIZE:
-    case ATCA_SMALL_BUFFER:
-    case ATCA_BAD_OPCODE:
-    case ATCA_ASSERT_FAILURE:
         return PSA_ERROR_INVALID_ARGUMENT;
+    case ATCA_ASSERT_FAILURE:
+        return PSA_ERROR_TAMPERING_DETECTED;
+    case ATCA_SMALL_BUFFER:
+        return PSA_ERROR_BUFFER_TOO_SMALL;
     case ATCA_RX_CRC_ERROR:
     case ATCA_RX_FAIL:
     case ATCA_STATUS_CRC:
@@ -88,6 +88,7 @@ static psa_status_t atecc608a_to_psa_error(ATCA_STATUS ret)
         return PSA_ERROR_NOT_SUPPORTED;
     case ATCA_ALLOC_FAILURE:
         return PSA_ERROR_INSUFFICIENT_MEMORY;
+    case ATCA_BAD_OPCODE:
     case ATCA_CONFIG_ZONE_LOCKED:
     case ATCA_DATA_ZONE_LOCKED:
     case ATCA_NOT_LOCKED:
@@ -101,6 +102,7 @@ static psa_status_t atecc608a_to_psa_error(ATCA_STATUS ret)
     case ATCA_GEN_FAIL:
     case ATCA_EXECUTION_ERROR:
     case ATCA_HEALTH_TEST_ERROR:
+    case ATCA_INVALID_SIZE:
     default:
         return PSA_ERROR_HARDWARE_FAILURE;
     }

--- a/atecc608a_se.c
+++ b/atecc608a_se.c
@@ -201,6 +201,11 @@ psa_status_t atecc608a_asymmetric_sign(psa_key_slot_number_t key_slot,
         return PSA_ERROR_NOT_SUPPORTED;
     }
 
+    if(signature_size < ATCA_SIG_SIZE)
+    {
+        return PSA_ERROR_BUFFER_TOO_SMALL;
+    }
+
     ATCAB_INIT();
 
     /* Signature will be returned here. Format is R and S integers in
@@ -208,7 +213,7 @@ psa_status_t atecc608a_asymmetric_sign(psa_key_slot_number_t key_slot,
     ASSERT_SUCCESS((ret = atcab_sign(key_id, p_hash, p_signature)),
                    atecc608a_to_psa_error(ret));
          
-    *p_signature_length = 64;
+    *p_signature_length = ATCA_SIG_SIZE;
 
 #ifdef DEBUG_PRINT
     printf("atecc608a_asymmetric_sign - signature size %d:\n", *p_signature_length);

--- a/atecc608a_se.c
+++ b/atecc608a_se.c
@@ -124,7 +124,7 @@ psa_status_t atecc608a_get_serial_number(uint8_t* buffer, size_t buffer_size,
     ASSERT_SUCCESS(atcab_read_serial_number(buffer));
     *buffer_length = ATCA_SERIAL_NUM_SIZE;
 
-    exit:
+exit:
     ATCAB_DEINIT();
     return status;
 }
@@ -138,7 +138,7 @@ psa_status_t atecc608a_check_config_locked()
 
     ASSERT_SUCCESS(atcab_is_locked(LOCK_ZONE_CONFIG, &config_locked));
 
-    exit:
+exit:
     ATCAB_DEINIT();
     if(status == PSA_SUCCESS)
     {
@@ -174,7 +174,7 @@ psa_status_t atecc608a_export_public_key(psa_key_slot_number_t key,
     atcab_printbin_sp(p_data, *p_data_length);
 #endif
 
-    exit:
+exit:
     ATCAB_DEINIT();
     return status;
 }
@@ -220,7 +220,7 @@ psa_status_t atecc608a_asymmetric_sign(psa_key_slot_number_t key_slot,
     atcab_printbin_sp(p_signature, *p_signature_length);
 #endif
 
-    exit:
+exit:
     ATCAB_DEINIT();
     return status;
 }

--- a/atecc608a_se.c
+++ b/atecc608a_se.c
@@ -10,6 +10,11 @@
 /* Uncomment to print results on success */
 //#define DEBUG_PRINT
 
+#ifdef DEBUG_PRINT
+#include <stdio.h>
+#endif
+#include <stdbool.h>
+
 ATCAIfaceCfg atca_iface_config = {
     .iface_type = ATCA_I2C_IFACE,
     .devtype = ATECC608A,

--- a/atecc608a_se.c
+++ b/atecc608a_se.c
@@ -158,6 +158,8 @@ psa_status_t atecc608a_export_public_key(psa_key_slot_number_t key,
 
     ATCAB_INIT();
 
+    /* atcab_get_pubkey returns concatenated x and y values, and the desired 
+       format is 0x04 + x + y. We start at &p_data[1] and add a 0x04 at p_data[0]. */
     ASSERT_SUCCESS((ret = atcab_get_pubkey(slot, &p_data[1])), atecc608a_to_psa_error(ret));
 
     p_data[0] = 4;
@@ -186,7 +188,6 @@ psa_status_t atecc608a_asymmetric_sign(psa_key_slot_number_t key_slot,
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
 
     /* We can only do ECDSA on SHA-256 */
-    /* PSA_ALG_ECDSA(PSA_ALG_SHA_256) */
     if (alg != PSA_ALG_ECDSA(PSA_ALG_SHA_256) && alg != PSA_ALG_ECDSA_ANY)
     {
         return PSA_ERROR_NOT_SUPPORTED;
@@ -202,7 +203,6 @@ psa_status_t atecc608a_asymmetric_sign(psa_key_slot_number_t key_slot,
 
     /* Signature will be returned here. Format is R and S integers in
      * big-endian format. 64 bytes for P256 curve. */
-
     ASSERT_SUCCESS((ret = atcab_sign(key_id, p_hash, p_signature)),
                    atecc608a_to_psa_error(ret));
          

--- a/atecc608a_se.c
+++ b/atecc608a_se.c
@@ -106,7 +106,8 @@ static psa_status_t atecc608a_to_psa_error(ATCA_STATUS ret)
     }
 }
 
-psa_status_t atecc608a_get_serial_number(uint8_t* buffer, size_t buffer_size)
+psa_status_t atecc608a_get_serial_number(uint8_t* buffer, size_t buffer_size,
+                                         size_t *buffer_length)
 {
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
 
@@ -118,6 +119,7 @@ psa_status_t atecc608a_get_serial_number(uint8_t* buffer, size_t buffer_size)
     ATCAB_INIT();
 
     ASSERT_SUCCESS(atcab_read_serial_number(buffer), PSA_ERROR_HARDWARE_FAILURE);
+    *buffer_length = ATCA_SERIAL_NUM_SIZE;
 
     exit:
     ATCAB_DEINIT();

--- a/atecc608a_se.c
+++ b/atecc608a_se.c
@@ -1,0 +1,212 @@
+#include "atecc608a_se.h"
+
+#include "atca_status.h"
+#include "atca_devtypes.h"
+#include "atca_iface.h"
+#include "atca_command.h"
+#include "atca_basic.h"
+#include "atca_helpers.h"
+
+/* Uncomment to print results on success */
+//#define DEBUG_PRINT
+
+ATCAIfaceCfg atca_iface_config = {
+    .iface_type = ATCA_I2C_IFACE,
+    .devtype = ATECC608A,
+    .atcai2c.slave_address = 0xC0,
+    .atcai2c.bus = 2,
+    .atcai2c.baud = 400000,
+    .wake_delay = 1500,
+    .rx_retries = 20,
+};
+
+static psa_status_t atecc608a_to_psa_error(ATCA_STATUS ret)
+{
+    switch (ret)
+    {
+    case ATCA_SUCCESS:
+    case ATCA_RX_NO_RESPONSE:
+    case ATCA_WAKE_SUCCESS:
+        return PSA_SUCCESS;
+    case ATCA_BAD_PARAM:
+    case ATCA_INVALID_ID:
+    case ATCA_INVALID_SIZE:
+    case ATCA_SMALL_BUFFER:
+    case ATCA_BAD_OPCODE:
+    case ATCA_ASSERT_FAILURE:
+        return PSA_ERROR_INVALID_ARGUMENT;
+    case ATCA_RX_CRC_ERROR:
+    case ATCA_RX_FAIL:
+    case ATCA_STATUS_CRC:
+    case ATCA_RESYNC_WITH_WAKEUP:
+    case ATCA_PARITY_ERROR:
+    case ATCA_TX_TIMEOUT:
+    case ATCA_RX_TIMEOUT:
+    case ATCA_TOO_MANY_COMM_RETRIES:
+    case ATCA_COMM_FAIL:
+    case ATCA_TIMEOUT:
+    case ATCA_TX_FAIL:
+    case ATCA_NO_DEVICES:
+        return PSA_ERROR_COMMUNICATION_FAILURE;
+    case ATCA_UNIMPLEMENTED:
+        return PSA_ERROR_NOT_SUPPORTED;
+    case ATCA_ALLOC_FAILURE:
+        return PSA_ERROR_INSUFFICIENT_MEMORY;
+    case ATCA_CONFIG_ZONE_LOCKED:
+    case ATCA_DATA_ZONE_LOCKED:
+    case ATCA_NOT_LOCKED:
+    case ATCA_WAKE_FAILED:
+    case ATCA_STATUS_UNKNOWN:
+    case ATCA_STATUS_ECC:
+    case ATCA_STATUS_SELFTEST_ERROR:
+    case ATCA_CHECKMAC_VERIFY_FAILED:
+    case ATCA_PARSE_ERROR:
+    case ATCA_FUNC_FAIL:
+    case ATCA_GEN_FAIL:
+    case ATCA_EXECUTION_ERROR:
+    case ATCA_HEALTH_TEST_ERROR:
+    default:
+        return PSA_ERROR_HARDWARE_FAILURE;
+    }
+}
+
+psa_status_t atecc608a_get_serial_number(uint8_t* buffer, size_t buffer_size)
+{
+
+    if (buffer_size < ATCA_SERIAL_NUM_SIZE)
+    {
+        return PSA_ERROR_BUFFER_TOO_SMALL;
+    }
+
+    if (atcab_init(&atca_iface_config) != ATCA_SUCCESS)
+    {
+        return PSA_ERROR_HARDWARE_FAILURE;
+    }
+
+    if (atcab_read_serial_number(buffer) != ATCA_SUCCESS)
+    {
+        atcab_release();
+        return PSA_ERROR_HARDWARE_FAILURE;
+    }
+
+    if (atcab_release() != ATCA_SUCCESS)
+    {
+        return PSA_ERROR_HARDWARE_FAILURE;
+    }
+
+    return PSA_SUCCESS;
+}
+
+psa_status_t atecc608a_check_config_locked()
+{
+    bool config_locked;
+
+    if (atcab_init(&atca_iface_config) != ATCA_SUCCESS)
+    {
+        return PSA_ERROR_HARDWARE_FAILURE;
+    }
+
+    if (atcab_is_locked(LOCK_ZONE_CONFIG, &config_locked) != ATCA_SUCCESS)
+    {
+        atcab_release();
+        return PSA_ERROR_HARDWARE_FAILURE;
+    }
+
+    if (atcab_release() != ATCA_SUCCESS)
+    {
+        return PSA_ERROR_HARDWARE_FAILURE;
+    }
+
+    return config_locked? PSA_SUCCESS : PSA_ERROR_HARDWARE_FAILURE;
+}
+
+psa_status_t atecc608a_export_public_key(psa_key_slot_number_t key,
+                                         uint8_t *p_data, size_t data_size,
+                                         size_t *p_data_length)
+{
+    const size_t key_data_len = 65;
+    const uint16_t slot = key;
+    ATCA_STATUS ret = ATCA_SUCCESS;
+
+    if (data_size < key_data_len)
+    {
+        return PSA_ERROR_BUFFER_TOO_SMALL;
+    }
+
+    if (atcab_init(&atca_iface_config) != ATCA_SUCCESS)
+    {
+        return PSA_ERROR_HARDWARE_FAILURE;
+    }
+
+    if ((ret = atcab_get_pubkey(slot, &p_data[1])) != ATCA_SUCCESS)
+    {
+        atcab_release();
+        return atecc608a_to_psa_error(ret);
+    }
+    p_data[0] = 4;
+    *p_data_length = key_data_len;
+
+    if (atcab_release() != ATCA_SUCCESS)
+    {
+        return PSA_ERROR_HARDWARE_FAILURE;
+    }
+
+#ifdef DEBUG_PRINT
+    printf("atecc608a_export_key - pubkey size %d:\n", *p_data_length);
+    atcab_printbin_sp(p_data, *p_data_length);
+#endif
+
+    return PSA_SUCCESS;
+}
+
+psa_status_t atecc608a_asymmetric_sign(psa_key_slot_number_t key_slot,
+                                       psa_algorithm_t alg,
+                                       const uint8_t *p_hash,
+                                       size_t hash_length,
+                                       uint8_t *p_signature,
+                                       size_t signature_size,
+                                       size_t *p_signature_length)
+{
+    ATCA_STATUS ret = ATCA_SUCCESS;
+    const uint16_t key_id = key_slot;
+
+    /* We can only do ECDSA on SHA-256 */
+    /* PSA_ALG_ECDSA(PSA_ALG_SHA_256) */
+    if (alg != PSA_ALG_ECDSA(PSA_ALG_SHA_256) && alg != PSA_ALG_ECDSA_ANY)
+    {
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
+
+    if (hash_length != 32)
+    {
+        /* The driver only supports signing things of length 32. */
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
+
+    if (atcab_init(&atca_iface_config) != ATCA_SUCCESS)
+    {
+        return PSA_ERROR_HARDWARE_FAILURE;
+    }
+
+    /* Signature will be returned here. Format is R and S integers in
+     * big-endian format. 64 bytes for P256 curve. */
+
+    if ((ret = atcab_sign(key_id, p_hash, p_signature)) != ATCA_SUCCESS)
+    {
+        atcab_release();
+        return atecc608a_to_psa_error(ret);
+    }
+
+    *p_signature_length = 64;
+    if (atcab_release() != ATCA_SUCCESS)
+    {
+        return PSA_ERROR_HARDWARE_FAILURE;
+    }
+
+#ifdef DEBUG_PRINT
+    printf("atecc608a_asymmetric_sign - signature size %d:\n", *p_signature_length);
+    atcab_printbin_sp(p_signature, *p_signature_length);
+#endif
+
+    return PSA_SUCCESS;
+}

--- a/atecc608a_se.h
+++ b/atecc608a_se.h
@@ -1,0 +1,40 @@
+/**
+ * \file atecc608a_se.h
+ * \brief Secure element implementation for ATECC508A and ATECC509A
+ */
+
+/*
+ *  Copyright (C) 2019, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef ATECC608A_SE_H
+#define ATECC608A_SE_H
+
+#include "psa/crypto.h"
+
+psa_status_t atecc608a_get_serial_number(uint8_t* buffer, size_t buffer_size);
+psa_status_t atecc608a_check_config_locked();
+psa_status_t atecc608a_export_public_key(psa_key_slot_number_t key, uint8_t *p_data,
+                                         size_t data_size, size_t *p_data_length);
+psa_status_t atecc608a_asymmetric_sign(psa_key_slot_number_t key_slot,
+                                       psa_algorithm_t alg,
+                                       const uint8_t *p_hash,
+                                       size_t hash_length,
+                                       uint8_t *p_signature,
+                                       size_t signature_size,
+                                       size_t *p_signature_length);
+
+#endif /* ATECC608A_SE_H */

--- a/atecc608a_se.h
+++ b/atecc608a_se.h
@@ -26,7 +26,8 @@
 #include <stdint.h>
 #include "psa/crypto.h"
 
-psa_status_t atecc608a_get_serial_number(uint8_t* buffer, size_t buffer_size);
+psa_status_t atecc608a_get_serial_number(uint8_t* buffer, size_t buffer_size,
+                                         size_t *buffer_length);
 psa_status_t atecc608a_check_config_locked();
 psa_status_t atecc608a_export_public_key(psa_key_slot_number_t key, uint8_t *p_data,
                                          size_t data_size, size_t *p_data_length);

--- a/atecc608a_se.h
+++ b/atecc608a_se.h
@@ -23,6 +23,7 @@
 #ifndef ATECC608A_SE_H
 #define ATECC608A_SE_H
 
+#include <stdint.h>
 #include "psa/crypto.h"
 
 psa_status_t atecc608a_get_serial_number(uint8_t* buffer, size_t buffer_size);

--- a/atecc608a_se.h
+++ b/atecc608a_se.h
@@ -27,29 +27,11 @@
 #include "atca_basic.h"
 
 extern psa_drv_se_info_t atecc608a_drv_info;
-extern ATCAIfaceCfg atca_iface_config;
 
 psa_status_t atecc608a_to_psa_error(ATCA_STATUS ret);
 
-#define ATCAB_INIT()                                        \
-    do                                                      \
-    {                                                       \
-        if (atcab_init(&atca_iface_config) != ATCA_SUCCESS) \
-        {                                                   \
-            status = PSA_ERROR_HARDWARE_FAILURE;            \
-            goto exit;                                      \
-        }                                                   \
-    } while(0)
+psa_status_t atecc608a_init();
 
-/** `atcab_release()` might return `ATCA_BAD_PARAM` if there is no global device
- *  initialized via `atcab_init()`. HAL might return an error if an i2c device
- *  cannot be released, but in current implementations it always returns
- *  `ATCA_SUCCESS` - therefore we are ignoring the return code. */
-#define ATCAB_DEINIT()    \
-    do                    \
-    {                     \
-        atcab_release();  \
-    } while(0)
+psa_status_t atecc608a_deinit();
 
-        
 #endif /* ATECC608A_SE_H */

--- a/atecc608a_se.h
+++ b/atecc608a_se.h
@@ -24,7 +24,32 @@
 #define ATECC608A_SE_H
 
 #include "psa/crypto_se_driver.h"
+#include "atca_basic.h"
 
 extern psa_drv_se_info_t atecc608a_drv_info;
+extern ATCAIfaceCfg atca_iface_config;
 
+psa_status_t atecc608a_to_psa_error(ATCA_STATUS ret);
+
+#define ATCAB_INIT()                                        \
+    do                                                      \
+    {                                                       \
+        if (atcab_init(&atca_iface_config) != ATCA_SUCCESS) \
+        {                                                   \
+            status = PSA_ERROR_HARDWARE_FAILURE;            \
+            goto exit;                                      \
+        }                                                   \
+    } while(0)
+
+/** `atcab_release()` might return `ATCA_BAD_PARAM` if there is no global device
+ *  initialized via `atcab_init()`. HAL might return an error if an i2c device
+ *  cannot be released, but in current implementations it always returns
+ *  `ATCA_SUCCESS` - therefore we are ignoring the return code. */
+#define ATCAB_DEINIT()    \
+    do                    \
+    {                     \
+        atcab_release();  \
+    } while(0)
+
+        
 #endif /* ATECC608A_SE_H */

--- a/atecc608a_se.h
+++ b/atecc608a_se.h
@@ -1,6 +1,6 @@
 /**
  * \file atecc608a_se.h
- * \brief Secure element implementation for ATECC508A and ATECC509A
+ * \brief Secure element driver structure for ATECC508A and ATECC509A.
  */
 
 /*
@@ -23,20 +23,8 @@
 #ifndef ATECC608A_SE_H
 #define ATECC608A_SE_H
 
-#include <stdint.h>
-#include "psa/crypto.h"
+#include "psa/crypto_se_driver.h"
 
-psa_status_t atecc608a_get_serial_number(uint8_t* buffer, size_t buffer_size,
-                                         size_t *buffer_length);
-psa_status_t atecc608a_check_config_locked();
-psa_status_t atecc608a_export_public_key(psa_key_slot_number_t key, uint8_t *p_data,
-                                         size_t data_size, size_t *p_data_length);
-psa_status_t atecc608a_asymmetric_sign(psa_key_slot_number_t key_slot,
-                                       psa_algorithm_t alg,
-                                       const uint8_t *p_hash,
-                                       size_t hash_length,
-                                       uint8_t *p_signature,
-                                       size_t signature_size,
-                                       size_t *p_signature_length);
+extern psa_drv_se_info_t atecc608a_drv_info;
 
 #endif /* ATECC608A_SE_H */


### PR DESCRIPTION
This is a continuation of https://github.com/ARMmbed/mbed-os-atecc608a/pull/2.

This PR implements hardware ECDSA signing and public key exporting using ATECC608A or ATECC508A.
Prerequisite - a cryptoauth device (508A or 608A) comissioned, with a locked configuration and a private key generated in slot 0 (warning - configuration locking is irreversible!). An example application doing this with a quite safe config can be seen here.

This PR is a prerequisite for ARMmbed/mbed-os-example-atecc608a#2.