### PR TITLE
Add support for writing to and reading from a slot

### DIFF
--- a/atecc608a_se.c
+++ b/atecc608a_se.c
@@ -219,7 +219,7 @@ static psa_status_t atecc608a_import_public_key(psa_key_slot_number_t key_slot,
 
     ASSERT_SUCCESS_PSA(atecc608a_init());
 
-    ASSERT_SUCCESS(atcab_write_pubkey(key_id, pubkey_for_driver(p_data)));
+    ASSERT_SUCCESS(atcab_write_pubkey(key_id, pubkey_for_driver((uint8_t *) p_data)));
 exit:
     atecc608a_deinit();
     return status;

--- a/atecc608a_se.c
+++ b/atecc608a_se.c
@@ -367,6 +367,42 @@ exit:
     return status;
 }
 
+psa_status_t atecc608a_write(uint16_t slot, size_t offset, const uint8_t *data, size_t length)
+{
+    psa_status_t status = PSA_ERROR_GENERIC_ERROR;
+
+    /* The hardware has slots 0-15 */
+    if (slot > 15)
+    {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+
+    ASSERT_SUCCESS_PSA(atecc608a_init());
+    ASSERT_SUCCESS(atcab_write_bytes_zone(ATCA_ZONE_DATA, slot, offset, data, length));
+
+exit:
+    atecc608a_deinit();
+    return status;
+}
+
+psa_status_t atecc608a_read(uint16_t slot, size_t offset, uint8_t *data, size_t length)
+{
+    psa_status_t status = PSA_ERROR_GENERIC_ERROR;
+
+    /* The hardware has slots 0-15 */
+    if (slot > 15)
+    {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+
+    ASSERT_SUCCESS_PSA(atecc608a_init());
+    ASSERT_SUCCESS(atcab_read_bytes_zone(ATCA_ZONE_DATA, slot, offset, data, length));
+
+exit:
+    atecc608a_deinit();
+    return status;
+}
+
 #define PSA_ATECC608A_LIFETIME 0xdeadbeefU
 
 static psa_drv_se_asymmetric_t atecc608a_asymmetric =

--- a/atecc608a_se.h
+++ b/atecc608a_se.h
@@ -34,4 +34,14 @@ psa_status_t atecc608a_init();
 
 psa_status_t atecc608a_deinit();
 
+/** Read from a given slot at an offset. Data zone has to be locked for this
+ *  function to work. */
+psa_status_t atecc608a_read(uint16_t slot, size_t offset, uint8_t *data, size_t length);
+
+/** Write to a given slot at an offset. If the data zone is locked, offset and
+ *  length must be multiples of a word (4 bytes). If the data zone is unlocked,
+ *  only 32-byte writes are allowed, and the offset and length must be
+ *  multiples of 32. */
+psa_status_t atecc608a_write(uint16_t slot, size_t offset, const uint8_t *data, size_t length);
+
 #endif /* ATECC608A_SE_H */


### PR DESCRIPTION
Support added for a clear text read and write. Please review only the two write/read commits.
This is a prerequisite for https://github.com/ARMmbed/mbed-os-example-atecc608a/pull/5.
