### PR TITLE
Adjust the driver to the new PSA API

### DIFF
--- a/atecc608a_se.c
+++ b/atecc608a_se.c
@@ -221,11 +221,10 @@ static psa_status_t atecc608a_import_public_key(
     ASSERT_SUCCESS(atcab_write_pubkey(key_id, pubkey_for_driver((uint8_t *) data)));
 
     if (bits != NULL) {
-        /* The 64-byte key is written as 72 bytes. See atcab_write_pubkey() for
-         * why 72 bytes. */
-        *bits = PSA_BYTES_TO_BITS(72);
+        /* The 64-byte key is stored in the SE as 72 bytes, but we return 64 as
+         * the actual key size. */
+        *bits = PSA_BYTES_TO_BITS(64);
     }
-
 exit:
     atecc608a_deinit();
     return status;

--- a/atecc608a_se.c
+++ b/atecc608a_se.c
@@ -165,6 +165,8 @@ static psa_status_t atecc608a_export_public_key(psa_drv_se_context_t *drv_contex
     const uint16_t slot = key;
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
 
+    (void) drv_context;
+
     if (data_size < key_data_len) {
         return PSA_ERROR_BUFFER_TOO_SMALL;
     }
@@ -185,6 +187,7 @@ exit:
     atecc608a_deinit();
     return status;
 }
+
 static psa_status_t atecc608a_import_public_key(
     psa_drv_se_context_t *drv_context,
     psa_key_slot_number_t key_slot,
@@ -198,6 +201,7 @@ static psa_status_t atecc608a_import_public_key(
     psa_key_type_t type = psa_get_key_type(attributes);
     psa_algorithm_t alg = psa_get_key_algorithm(attributes);
 
+    (void) drv_context;
     ASSERT_SUCCESS_PSA(is_public_key_slot(key_id));
 
     /* Check if the key has a size of 65 {0x04, X, Y}. */
@@ -241,6 +245,7 @@ static psa_status_t atecc608a_generate_key(
     psa_key_type_t type = psa_get_key_type(attributes);
     size_t bits = psa_get_key_bits(attributes);
 
+    (void) drv_context;
     /* The hardware has slots 0-15 */
     if (key_slot > 15) {
         return PSA_ERROR_INVALID_ARGUMENT;
@@ -288,6 +293,7 @@ static psa_status_t atecc608a_asymmetric_sign(psa_drv_se_context_t *drv_context,
     const uint16_t key_id = key_slot;
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
 
+    (void) drv_context;
     /* The driver can only do randomized ECDSA on SHA-256 */
     if (alg != PSA_ALG_ECDSA(PSA_ALG_SHA_256) && alg != PSA_ALG_ECDSA_ANY) {
         return PSA_ERROR_NOT_SUPPORTED;
@@ -332,6 +338,7 @@ psa_status_t atecc608a_asymmetric_verify(psa_drv_se_context_t *drv_context,
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
     bool is_verified = false;
 
+    (void) drv_context;
     ASSERT_SUCCESS_PSA(is_public_key_slot(key_id));
 
     /* The driver can only do randomized ECDSA on SHA-256 */
@@ -399,6 +406,9 @@ static psa_status_t atecc608a_validate_slot_number(
     psa_key_slot_number_t key_slot)
 {
     psa_key_type_t type = psa_get_key_type(attributes);
+    (void) drv_context;
+    (void) method;
+
     if (PSA_KEY_TYPE_IS_ECC_KEY_PAIR(type)) {
         if (key_slot <= 15) {
             return PSA_SUCCESS;
@@ -418,6 +428,12 @@ static psa_status_t atecc608a_allocate_key(
     psa_key_creation_method_t method,
     psa_key_slot_number_t *key_slot)
 {
+    (void) drv_context;
+    (void) persistent_data;
+    (void) attributes;
+    (void) method;
+    (void) key_slot;
+
     return PSA_SUCCESS;
 }
 

--- a/atecc608a_se.c
+++ b/atecc608a_se.c
@@ -268,9 +268,7 @@ static psa_status_t atecc608a_generate_key(
         ASSERT_SUCCESS(atcab_genkey(key_id, NULL));
     }
 
-    if (pubkey_length != NULL) {
-        *pubkey_length = 1 + ATCA_PUB_KEY_SIZE;
-    }
+    *pubkey_length = 1 + ATCA_PUB_KEY_SIZE;
 
 exit:
     atecc608a_deinit();

--- a/atecc608a_se.c
+++ b/atecc608a_se.c
@@ -418,6 +418,9 @@ static psa_status_t atecc608a_allocate_key(
     (void) method;
     (void) key_slot;
 
+    /* TODO - this function is not implemented yet. It will contain
+       persistent data handling to ensure that a single slot
+       will not be allocated twice. */
     return PSA_SUCCESS;
 }
 

--- a/atecc608a_se.c
+++ b/atecc608a_se.c
@@ -125,13 +125,13 @@ psa_status_t atecc608a_to_psa_error(ATCA_STATUS ret)
  * format for pubkeys is 0x04 + x + y. Always use a pubkey buffer in PSA
  * format, with enough space for the PSA format. To translate this buffer for
  * use with cryptoauthlib, use pubkey_for_driver(). To ensure the buffer is in
- * valid PSA format after cryptoauthlib operations, call pubkey_for_psa(). */
+ * valid PSA format after cryptoauthlib operations, call set_psa_pubkey_prefix(). */
 static uint8_t *pubkey_for_driver(uint8_t *data)
 {
     return &data[1];
 }
 
-static void pubkey_for_psa(uint8_t *data)
+static void set_psa_pubkey_prefix(uint8_t *data)
 {
     data[0] = 0x4;
 }
@@ -174,7 +174,7 @@ static psa_status_t atecc608a_export_public_key(psa_drv_se_context_t *drv_contex
     ASSERT_SUCCESS_PSA(atecc608a_init());
 
     ASSERT_SUCCESS(atcab_get_pubkey(slot, pubkey_for_driver(p_data)));
-    pubkey_for_psa(p_data);
+    set_psa_pubkey_prefix(p_data);
 
     *p_data_length = key_data_len;
 
@@ -265,7 +265,7 @@ static psa_status_t atecc608a_generate_key(
 
     if (pubkey != NULL) {
         ASSERT_SUCCESS(atcab_genkey(key_id, pubkey_for_driver(pubkey)));
-        pubkey_for_psa(pubkey);
+        set_psa_pubkey_prefix(pubkey);
     } else {
         ASSERT_SUCCESS(atcab_genkey(key_id, NULL));
     }

--- a/atecc608a_se.c
+++ b/atecc608a_se.c
@@ -72,53 +72,52 @@ static ATCAIfaceCfg atca_iface_config = {
 
 psa_status_t atecc608a_to_psa_error(ATCA_STATUS ret)
 {
-    switch (ret)
-    {
-    case ATCA_SUCCESS:
-    case ATCA_RX_NO_RESPONSE:
-    case ATCA_WAKE_SUCCESS:
-        return PSA_SUCCESS;
-    case ATCA_BAD_PARAM:
-    case ATCA_INVALID_ID:
-        return PSA_ERROR_INVALID_ARGUMENT;
-    case ATCA_ASSERT_FAILURE:
-        return PSA_ERROR_TAMPERING_DETECTED;
-    case ATCA_SMALL_BUFFER:
-        return PSA_ERROR_BUFFER_TOO_SMALL;
-    case ATCA_RX_CRC_ERROR:
-    case ATCA_RX_FAIL:
-    case ATCA_STATUS_CRC:
-    case ATCA_RESYNC_WITH_WAKEUP:
-    case ATCA_PARITY_ERROR:
-    case ATCA_TX_TIMEOUT:
-    case ATCA_RX_TIMEOUT:
-    case ATCA_TOO_MANY_COMM_RETRIES:
-    case ATCA_COMM_FAIL:
-    case ATCA_TIMEOUT:
-    case ATCA_TX_FAIL:
-    case ATCA_NO_DEVICES:
-        return PSA_ERROR_COMMUNICATION_FAILURE;
-    case ATCA_UNIMPLEMENTED:
-        return PSA_ERROR_NOT_SUPPORTED;
-    case ATCA_ALLOC_FAILURE:
-        return PSA_ERROR_INSUFFICIENT_MEMORY;
-    case ATCA_BAD_OPCODE:
-    case ATCA_CONFIG_ZONE_LOCKED:
-    case ATCA_DATA_ZONE_LOCKED:
-    case ATCA_NOT_LOCKED:
-    case ATCA_WAKE_FAILED:
-    case ATCA_STATUS_UNKNOWN:
-    case ATCA_STATUS_ECC:
-    case ATCA_STATUS_SELFTEST_ERROR:
-    case ATCA_CHECKMAC_VERIFY_FAILED:
-    case ATCA_PARSE_ERROR:
-    case ATCA_FUNC_FAIL:
-    case ATCA_GEN_FAIL:
-    case ATCA_EXECUTION_ERROR:
-    case ATCA_HEALTH_TEST_ERROR:
-    case ATCA_INVALID_SIZE:
-    default:
-        return PSA_ERROR_HARDWARE_FAILURE;
+    switch (ret) {
+        case ATCA_SUCCESS:
+        case ATCA_RX_NO_RESPONSE:
+        case ATCA_WAKE_SUCCESS:
+            return PSA_SUCCESS;
+        case ATCA_BAD_PARAM:
+        case ATCA_INVALID_ID:
+            return PSA_ERROR_INVALID_ARGUMENT;
+        case ATCA_ASSERT_FAILURE:
+            return PSA_ERROR_CORRUPTION_DETECTED;
+        case ATCA_SMALL_BUFFER:
+            return PSA_ERROR_BUFFER_TOO_SMALL;
+        case ATCA_RX_CRC_ERROR:
+        case ATCA_RX_FAIL:
+        case ATCA_STATUS_CRC:
+        case ATCA_RESYNC_WITH_WAKEUP:
+        case ATCA_PARITY_ERROR:
+        case ATCA_TX_TIMEOUT:
+        case ATCA_RX_TIMEOUT:
+        case ATCA_TOO_MANY_COMM_RETRIES:
+        case ATCA_COMM_FAIL:
+        case ATCA_TIMEOUT:
+        case ATCA_TX_FAIL:
+        case ATCA_NO_DEVICES:
+            return PSA_ERROR_COMMUNICATION_FAILURE;
+        case ATCA_UNIMPLEMENTED:
+            return PSA_ERROR_NOT_SUPPORTED;
+        case ATCA_ALLOC_FAILURE:
+            return PSA_ERROR_INSUFFICIENT_MEMORY;
+        case ATCA_BAD_OPCODE:
+        case ATCA_CONFIG_ZONE_LOCKED:
+        case ATCA_DATA_ZONE_LOCKED:
+        case ATCA_NOT_LOCKED:
+        case ATCA_WAKE_FAILED:
+        case ATCA_STATUS_UNKNOWN:
+        case ATCA_STATUS_ECC:
+        case ATCA_STATUS_SELFTEST_ERROR:
+        case ATCA_CHECKMAC_VERIFY_FAILED:
+        case ATCA_PARSE_ERROR:
+        case ATCA_FUNC_FAIL:
+        case ATCA_GEN_FAIL:
+        case ATCA_EXECUTION_ERROR:
+        case ATCA_HEALTH_TEST_ERROR:
+        case ATCA_INVALID_SIZE:
+        default:
+            return PSA_ERROR_HARDWARE_FAILURE;
     }
 }
 
@@ -140,7 +139,7 @@ static void pubkey_for_psa(uint8_t *data)
 static psa_status_t is_public_key_slot(uint16_t key_slot)
 {
     /* Keys 8 to 15 can store public keys. Slots 1-7 are too small. */
-    return ((key_slot >= 8 && key_slot <=15) ? PSA_SUCCESS : PSA_ERROR_INVALID_ARGUMENT);
+    return ((key_slot >= 8 && key_slot <= 15) ? PSA_SUCCESS : PSA_ERROR_INVALID_ARGUMENT);
 }
 
 psa_status_t atecc608a_init()
@@ -153,8 +152,10 @@ psa_status_t atecc608a_deinit()
     return atecc608a_to_psa_error(atcab_release());
 }
 
-static psa_status_t atecc608a_export_public_key(psa_key_slot_number_t key,
-                                                uint8_t *p_data, size_t data_size,
+static psa_status_t atecc608a_export_public_key(psa_drv_se_context_t *drv_context,
+                                                psa_key_slot_number_t key,
+                                                uint8_t *p_data,
+                                                size_t data_size,
                                                 size_t *p_data_length)
 {
     const size_t key_data_len = PSA_KEY_EXPORT_MAX_SIZE(
@@ -164,8 +165,7 @@ static psa_status_t atecc608a_export_public_key(psa_key_slot_number_t key,
     const uint16_t slot = key;
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
 
-    if (data_size < key_data_len)
-    {
+    if (data_size < key_data_len) {
         return PSA_ERROR_BUFFER_TOO_SMALL;
     }
 
@@ -185,95 +185,91 @@ exit:
     atecc608a_deinit();
     return status;
 }
-static psa_status_t atecc608a_import_public_key(psa_key_slot_number_t key_slot,
-                                                psa_key_lifetime_t lifetime,
-                                                psa_key_type_t type,
-                                                psa_algorithm_t alg,
-                                                psa_key_usage_t usage,
-                                                const uint8_t *p_data,
-                                                size_t data_length)
+static psa_status_t atecc608a_import_public_key(
+    psa_drv_se_context_t *drv_context,
+    psa_key_slot_number_t key_slot,
+    const psa_key_attributes_t *attributes,
+    const uint8_t *data,
+    size_t data_length,
+    size_t *bits)
 {
     const uint16_t key_id = key_slot;
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
+    psa_key_type_t type = psa_get_key_type(attributes);
+    psa_algorithm_t alg = psa_get_key_algorithm(attributes);
 
     ASSERT_SUCCESS_PSA(is_public_key_slot(key_id));
 
     /* Check if the key has a size of 65 {0x04, X, Y}. */
     if (data_length != PSA_KEY_EXPORT_MAX_SIZE(PSA_KEY_TYPE_ECC_PUBLIC_KEY(
                                                    PSA_ECC_CURVE_SECP256R1),
-                                               256))
-    {
+                                               256)) {
         return PSA_ERROR_INVALID_ARGUMENT;
     }
 
-    if (type != PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_CURVE_SECP256R1))
-    {
+    if (type != PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_CURVE_SECP256R1)) {
         return PSA_ERROR_NOT_SUPPORTED;
     }
 
     /* The driver can only do randomized ECDSA on SHA-256 */
-    if (alg != PSA_ALG_ECDSA(PSA_ALG_SHA_256) && alg != PSA_ALG_ECDSA_ANY)
-    {
+    if (alg != PSA_ALG_ECDSA(PSA_ALG_SHA_256) && alg != PSA_ALG_ECDSA_ANY) {
         return PSA_ERROR_NOT_SUPPORTED;
     }
 
     ASSERT_SUCCESS_PSA(atecc608a_init());
 
-    ASSERT_SUCCESS(atcab_write_pubkey(key_id, pubkey_for_driver((uint8_t *) p_data)));
+    ASSERT_SUCCESS(atcab_write_pubkey(key_id, pubkey_for_driver((uint8_t *) data)));
+
+    if (bits != NULL) {
+        /* The 64-byte key is written as 72 bytes. See atcab_write_pubkey() for
+         * why 72 bytes. */
+        *bits = PSA_BYTES_TO_BITS(72);
+    }
+
 exit:
     atecc608a_deinit();
     return status;
 }
 
-static psa_status_t atecc608a_generate_key(psa_key_slot_number_t key_slot,
-                                           psa_key_type_t type,
-                                           psa_key_usage_t usage,
-                                           size_t bits,
-                                           const void *extra,
-                                           size_t extra_size,
-                                           uint8_t *p_pubkey_out,
-                                           size_t pubkey_out_size,
-                                           size_t *p_pubkey_length)
+static psa_status_t atecc608a_generate_key(
+    psa_drv_se_context_t *drv_context,
+    psa_key_slot_number_t key_slot,
+    const psa_key_attributes_t *attributes,
+    uint8_t *pubkey, size_t pubkey_size, size_t *pubkey_length)
 {
     const uint16_t key_id = key_slot;
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
+    psa_key_type_t type = psa_get_key_type(attributes);
+    size_t bits = psa_get_key_bits(attributes);
 
     /* The hardware has slots 0-15 */
-    if (key_slot > 15)
-    {
+    if (key_slot > 15) {
         return PSA_ERROR_INVALID_ARGUMENT;
     }
 
-    if (type != PSA_KEY_TYPE_ECC_KEYPAIR(PSA_ECC_CURVE_SECP256R1))
-    {
+    if (type != PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP256R1)) {
         return PSA_ERROR_NOT_SUPPORTED;
     }
 
-    if (bits != PSA_BYTES_TO_BITS(ATCA_PRIV_KEY_SIZE))
-    {
+    if (bits != PSA_BYTES_TO_BITS(ATCA_PRIV_KEY_SIZE)) {
         return PSA_ERROR_NOT_SUPPORTED;
     }
 
-    if (p_pubkey_out != NULL && pubkey_out_size < 1 + ATCA_PUB_KEY_SIZE)
-    {
-       return PSA_ERROR_BUFFER_TOO_SMALL;
+    if (pubkey != NULL && pubkey_size < 1 + ATCA_PUB_KEY_SIZE) {
+        return PSA_ERROR_BUFFER_TOO_SMALL;
     }
 
     ASSERT_SUCCESS_PSA(atecc608a_init());
 
-    if (p_pubkey_out != NULL)
-    {
-        ASSERT_SUCCESS(atcab_genkey(key_id, pubkey_for_driver(p_pubkey_out)));
-        pubkey_for_psa(p_pubkey_out);
-    }
-    else
-    {
+    if (pubkey != NULL) {
+        ASSERT_SUCCESS(atcab_genkey(key_id, pubkey_for_driver(pubkey)));
+        pubkey_for_psa(pubkey);
+    } else {
         ASSERT_SUCCESS(atcab_genkey(key_id, NULL));
     }
 
-    if (p_pubkey_length != NULL)
-    {
-        *p_pubkey_length = 1 + ATCA_PUB_KEY_SIZE;
+    if (pubkey_length != NULL) {
+        *pubkey_length = 1 + ATCA_PUB_KEY_SIZE;
     }
 
 exit:
@@ -281,7 +277,8 @@ exit:
     return status;
 }
 
-static psa_status_t atecc608a_asymmetric_sign(psa_key_slot_number_t key_slot,
+static psa_status_t atecc608a_asymmetric_sign(psa_drv_se_context_t *drv_context,
+                                              psa_key_slot_number_t key_slot,
                                               psa_algorithm_t alg,
                                               const uint8_t *p_hash,
                                               size_t hash_length,
@@ -293,19 +290,16 @@ static psa_status_t atecc608a_asymmetric_sign(psa_key_slot_number_t key_slot,
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
 
     /* The driver can only do randomized ECDSA on SHA-256 */
-    if (alg != PSA_ALG_ECDSA(PSA_ALG_SHA_256) && alg != PSA_ALG_ECDSA_ANY)
-    {
+    if (alg != PSA_ALG_ECDSA(PSA_ALG_SHA_256) && alg != PSA_ALG_ECDSA_ANY) {
         return PSA_ERROR_NOT_SUPPORTED;
     }
 
-    if (hash_length != PSA_HASH_SIZE(PSA_ALG_SHA_256))
-    {
+    if (hash_length != PSA_HASH_SIZE(PSA_ALG_SHA_256)) {
         /* The driver only supports signing things of length 32. */
         return PSA_ERROR_NOT_SUPPORTED;
     }
 
-    if (signature_size < ATCA_SIG_SIZE)
-    {
+    if (signature_size < ATCA_SIG_SIZE) {
         return PSA_ERROR_BUFFER_TOO_SMALL;
     }
 
@@ -327,7 +321,8 @@ exit:
     return status;
 }
 
-psa_status_t atecc608a_asymmetric_verify(psa_key_slot_number_t key_slot,
+psa_status_t atecc608a_asymmetric_verify(psa_drv_se_context_t *drv_context,
+                                         psa_key_slot_number_t key_slot,
                                          psa_algorithm_t alg,
                                          const uint8_t *p_hash,
                                          size_t hash_length,
@@ -341,19 +336,16 @@ psa_status_t atecc608a_asymmetric_verify(psa_key_slot_number_t key_slot,
     ASSERT_SUCCESS_PSA(is_public_key_slot(key_id));
 
     /* The driver can only do randomized ECDSA on SHA-256 */
-    if (alg != PSA_ALG_ECDSA(PSA_ALG_SHA_256) && alg != PSA_ALG_ECDSA_ANY)
-    {
+    if (alg != PSA_ALG_ECDSA(PSA_ALG_SHA_256) && alg != PSA_ALG_ECDSA_ANY) {
         return PSA_ERROR_NOT_SUPPORTED;
     }
 
-    if (hash_length != PSA_HASH_SIZE(PSA_ALG_SHA_256))
-    {
+    if (hash_length != PSA_HASH_SIZE(PSA_ALG_SHA_256)) {
         /* The driver only supports hashes of length 32. */
         return PSA_ERROR_NOT_SUPPORTED;
     }
 
-    if (signature_length != ATCA_SIG_SIZE)
-    {
+    if (signature_length != ATCA_SIG_SIZE) {
         /* The driver only supports signatures of length 64. */
         return PSA_ERROR_INVALID_SIGNATURE;
     }
@@ -372,8 +364,7 @@ psa_status_t atecc608a_write(uint16_t slot, size_t offset, const uint8_t *data, 
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
 
     /* The hardware has slots 0-15 */
-    if (slot > 15)
-    {
+    if (slot > 15) {
         return PSA_ERROR_INVALID_ARGUMENT;
     }
 
@@ -390,8 +381,7 @@ psa_status_t atecc608a_read(uint16_t slot, size_t offset, uint8_t *data, size_t 
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
 
     /* The hardware has slots 0-15 */
-    if (slot > 15)
-    {
+    if (slot > 15) {
         return PSA_ERROR_INVALID_ARGUMENT;
     }
 
@@ -403,35 +393,59 @@ exit:
     return status;
 }
 
-#define PSA_ATECC608A_LIFETIME 0xdeadbeefU
-
-static psa_drv_se_asymmetric_t atecc608a_asymmetric =
+static psa_status_t atecc608a_validate_slot_number(
+    psa_drv_se_context_t *drv_context,
+    const psa_key_attributes_t *attributes,
+    psa_key_creation_method_t method,
+    psa_key_slot_number_t key_slot)
 {
+    psa_key_type_t type = psa_get_key_type(attributes);
+    if (PSA_KEY_TYPE_IS_ECC_KEY_PAIR(type)) {
+        if (key_slot <= 15) {
+            return PSA_SUCCESS;
+        }
+    } else if (PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(type)) {
+        if (key_slot >= 8 && key_slot <= 15) {
+            return PSA_SUCCESS;
+        }
+    }
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
+static psa_status_t atecc608a_allocate_key(
+    psa_drv_se_context_t *drv_context,
+    void *persistent_data,
+    const psa_key_attributes_t *attributes,
+    psa_key_creation_method_t method,
+    psa_key_slot_number_t *key_slot)
+{
+    return PSA_SUCCESS;
+}
+
+static psa_drv_se_asymmetric_t atecc608a_asymmetric = {
     .p_sign = atecc608a_asymmetric_sign,
     .p_verify = atecc608a_asymmetric_verify,
     .p_encrypt = 0,
     .p_decrypt = 0,
 };
 
-static psa_drv_se_key_management_t atecc608a_key_management =
-{
+static psa_drv_se_key_management_t atecc608a_key_management = {
     /* So far there is no public key import function in the API, so use this instead */
+    .p_allocate = atecc608a_allocate_key,
+    .p_validate_slot_number = atecc608a_validate_slot_number,
     .p_import = atecc608a_import_public_key,
     .p_generate = atecc608a_generate_key,
     .p_destroy = 0,
-    /* So far there is no public key export function in the API, so use this instead */
-    .p_export = atecc608a_export_public_key,
+    .p_export = 0,
+    .p_export_public = atecc608a_export_public_key,
 };
 
-psa_drv_se_info_t atecc608a_drv_info =
-{
-    .lifetime = PSA_ATECC608A_LIFETIME,
-    .p_key_management = &atecc608a_key_management,
-    .p_mac = 0,
-    .p_cipher = 0,
-    .p_asym = &atecc608a_asymmetric,
-    .p_aead = 0,
-    .p_derive = 0,
-    .slot_min = 0,
-    .slot_max = 0,
+psa_drv_se_t atecc608a_drv_info = {
+    .key_management = &atecc608a_key_management,
+    .mac = 0,
+    .cipher = 0,
+    .asymmetric = &atecc608a_asymmetric,
+    .aead = 0,
+    .derivation = 0,
+    .hal_version = PSA_DRV_SE_HAL_VERSION
 };

--- a/atecc608a_se.c
+++ b/atecc608a_se.c
@@ -246,10 +246,6 @@ static psa_status_t atecc608a_generate_key(
     size_t bits = psa_get_key_bits(attributes);
 
     (void) drv_context;
-    /* The hardware has slots 0-15 */
-    if (key_slot > 15) {
-        return PSA_ERROR_INVALID_ARGUMENT;
-    }
 
     if (type != PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP256R1)) {
         return PSA_ERROR_NOT_SUPPORTED;
@@ -369,11 +365,6 @@ psa_status_t atecc608a_write(uint16_t slot, size_t offset, const uint8_t *data, 
 {
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
 
-    /* The hardware has slots 0-15 */
-    if (slot > 15) {
-        return PSA_ERROR_INVALID_ARGUMENT;
-    }
-
     ASSERT_SUCCESS_PSA(atecc608a_init());
     ASSERT_SUCCESS(atcab_write_bytes_zone(ATCA_ZONE_DATA, slot, offset, data, length));
 
@@ -385,11 +376,6 @@ exit:
 psa_status_t atecc608a_read(uint16_t slot, size_t offset, uint8_t *data, size_t length)
 {
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
-
-    /* The hardware has slots 0-15 */
-    if (slot > 15) {
-        return PSA_ERROR_INVALID_ARGUMENT;
-    }
 
     ASSERT_SUCCESS_PSA(atecc608a_init());
     ASSERT_SUCCESS(atcab_read_bytes_zone(ATCA_ZONE_DATA, slot, offset, data, length));

--- a/atecc608a_se.c
+++ b/atecc608a_se.c
@@ -136,10 +136,10 @@ static void pubkey_for_psa(uint8_t *data)
     data[0] = 0x4;
 }
 
-static psa_status_t is_public_key_slot(uint16_t key_slot)
+static bool is_public_key_slot(uint16_t key_slot)
 {
     /* Keys 8 to 15 can store public keys. Slots 1-7 are too small. */
-    return ((key_slot >= 8 && key_slot <= 15) ? PSA_SUCCESS : PSA_ERROR_INVALID_ARGUMENT);
+    return (key_slot >= 8 && key_slot <= 15);
 }
 
 psa_status_t atecc608a_init()
@@ -202,7 +202,9 @@ static psa_status_t atecc608a_import_public_key(
     psa_algorithm_t alg = psa_get_key_algorithm(attributes);
 
     (void) drv_context;
-    ASSERT_SUCCESS_PSA(is_public_key_slot(key_id));
+    if (!is_public_key_slot(key_id)) {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
 
     /* Check if the key has a size of 65 {0x04, X, Y}. */
     if (data_length != PSA_KEY_EXPORT_MAX_SIZE(PSA_KEY_TYPE_ECC_PUBLIC_KEY(
@@ -333,7 +335,9 @@ psa_status_t atecc608a_asymmetric_verify(psa_drv_se_context_t *drv_context,
     bool is_verified = false;
 
     (void) drv_context;
-    ASSERT_SUCCESS_PSA(is_public_key_slot(key_id));
+    if (!is_public_key_slot(key_id)) {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
 
     /* The driver can only do randomized ECDSA on SHA-256 */
     if (alg != PSA_ALG_ECDSA(PSA_ALG_SHA_256) && alg != PSA_ALG_ECDSA_ANY) {

--- a/atecc608a_se.c
+++ b/atecc608a_se.c
@@ -227,9 +227,7 @@ static psa_status_t atecc608a_import_public_key(
     ASSERT_SUCCESS(atcab_write_pubkey(key_id, pubkey_for_driver((uint8_t *) data)));
 
     if (bits != NULL) {
-        /* The 64-byte key is stored in the SE as 72 bytes, but we return 64 as
-         * the actual key size. */
-        *bits = PSA_BYTES_TO_BITS(64);
+        *bits = 256;
     }
 exit:
     atecc608a_deinit();

--- a/atecc608a_se.c
+++ b/atecc608a_se.c
@@ -441,10 +441,10 @@ static psa_drv_se_key_management_t atecc608a_key_management = {
 
 psa_drv_se_t atecc608a_drv_info = {
     .key_management = &atecc608a_key_management,
-    .mac = 0,
-    .cipher = 0,
+    .mac = NULL,
+    .cipher = NULL,
     .asymmetric = &atecc608a_asymmetric,
-    .aead = 0,
-    .derivation = 0,
+    .aead = NULL,
+    .derivation = NULL,
     .hal_version = PSA_DRV_SE_HAL_VERSION
 };

--- a/atecc608a_se.h
+++ b/atecc608a_se.h
@@ -26,7 +26,8 @@
 #include "psa/crypto_se_driver.h"
 #include "atca_basic.h"
 
-extern psa_drv_se_info_t atecc608a_drv_info;
+#define PSA_ATECC608A_LIFETIME 0xf0
+extern psa_drv_se_t atecc608a_drv_info;
 
 psa_status_t atecc608a_to_psa_error(ATCA_STATUS ret);
 


### PR DESCRIPTION
Mostly API changes, with an addition of a check-slot function.
Changed the lifetime of the driver to fit the 0x00 - 0xFF range.
This PR is based on:
- https://github.com/ARMmbed/mbed-crypto/pull/157 - key foundation;
- https://github.com/ARMmbed/mbed-crypto/pull/183 - key registration;
- https://github.com/ARMmbed/mbed-crypto/pull/174 - hooks.

This PR is a base for https://github.com/ARMmbed/mbed-os-example-atecc608a/pull/10.