### PR TITLE
Configure ATECC608A driver I2C address and baud using Mbed OS configuration

### DIFF
--- a/atecc608a_se.c
+++ b/atecc608a_se.c
@@ -62,8 +62,8 @@
 
 static ATCAIfaceCfg atca_iface_config = {
     .iface_type = ATCA_I2C_IFACE,
-    .devtype = ATECC508A,
-    .atcai2c.slave_address = 0xC0,
+    .devtype = MBED_CONF_MBED_OS_ATECC608A_I2C_IFACE_DEVTYPE,
+    .atcai2c.slave_address = MBED_CONF_MBED_OS_ATECC608A_I2C_IFACE_SLAVE_ADDRESS,
     .atcai2c.bus = 2,
     .atcai2c.baud = 400000,
     .wake_delay = 1500,

--- a/mbed-cryptoauthlib.lib
+++ b/mbed-cryptoauthlib.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-cryptoauthlib/#f2ed31e6bdab3350dabd7b2f8fa5d4f9d81962ea
+https://github.com/ARMmbed/mbed-cryptoauthlib/#892af269daa91c2335ec83df22397911037481f0

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -1,0 +1,13 @@
+{
+    "name": "mbed-os-atecc608a",
+    "config": {
+        "i2c-iface-devtype": {
+            "help": "ATCA I2C device type",
+            "value": "ATECC508A"
+        },
+        "i2c-iface-slave_address": {
+            "help": "ATCA I2C slave address",
+            "value": "0xC0"
+        }
+    }
+}


### PR DESCRIPTION
The default device type is ATECC508A, slave address 0xC0