### PR TITLE
Update to mbed-cryptoauthlib for cryptoauthlib v3.1.0

### DIFF
--- a/mbed-cryptoauthlib.lib
+++ b/mbed-cryptoauthlib.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-cryptoauthlib/#892af269daa91c2335ec83df22397911037481f0
+https://github.com/ARMmbed/mbed-cryptoauthlib/#ef8fccafec44addfb035993b2e52cb8c79f6544f


### PR DESCRIPTION
Update mbed-cryptoauthlib to a version that pulls in cryptoauthlib
v3.1.0