### PR TITLE
cryptoauthlib: Update to ignore app/api_206a

### DIFF
--- a/mbed-cryptoauthlib.lib
+++ b/mbed-cryptoauthlib.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-cryptoauthlib/#ef8fccafec44addfb035993b2e52cb8c79f6544f
+https://github.com/ARMmbed/mbed-cryptoauthlib/#206c12987f27caf84f9dad46e04243501f923c01


### PR DESCRIPTION
Update to a version of mbed-cryptoauthlib that ignores cryptoauthlib's
app/api_206a app, as we don't need it. It also doesn't build with the
IAR compiler currently, so ignoring it helps us to be able to build
cryptoauthlib with IAR.